### PR TITLE
Add string, mutableString methods

### DIFF
--- a/Source/TextAttributes.swift
+++ b/Source/TextAttributes.swift
@@ -999,3 +999,28 @@ public class TextAttributes {
         return self
     }
 }
+
+extension TextAttributes {
+    
+    /**
+     Create and return AttributedString
+     
+     - parameter string: The text
+     
+     - returns: The AttributedString
+     */
+    public func string(string: String) -> NSAttributedString {
+        return NSAttributedString(string: string, attributes: self)
+    }
+    
+    /**
+     Create and return MutableAttributedString
+     
+     - parameter string: The text
+     
+     - returns: The MutableAttributedString
+     */
+    public func mutableString(string: String) -> NSMutableAttributedString {
+        return NSMutableAttributedString(string: string, attributes: self)
+    }
+}


### PR DESCRIPTION
I wrote an extension of `TextAttributes` to enable creating `NSAttributedString`s directly, like this:

``` swift
let attributedString = TextAttributes()
    .font(name: "HelveticaNeue", size: 16)
    .foregroundColor(white: 0.2, alpha: 1)
    .lineHeightMultiple(1.5)
    .string("The quick brown fox jumps over the lazy dog")
```

It will be even more easier to create attributed strings.
How do you think?
