### PR TITLE
Remove default value in initilizer

### DIFF
--- a/Source/AttributedString.swift
+++ b/Source/AttributedString.swift
@@ -31,7 +31,7 @@ extension NSAttributedString {
      
      - returns: The newly created NSAttributedString.
      */
-    public convenience init(string: NSString, attributes: TextAttributes? = nil) {
+    public convenience init(string: NSString, attributes: TextAttributes) {
         self.init(string: string as String, attributes: attributes)
     }
     
@@ -43,8 +43,8 @@ extension NSAttributedString {
      
      - returns: The newly created NSAttributedString.
      */
-    public convenience init(string: String, attributes: TextAttributes? = nil) {
-        self.init(string: string, attributes: attributes?.dictionary)
+    public convenience init(string: String, attributes: TextAttributes) {
+        self.init(string: string, attributes: attributes.dictionary)
     }
 }
 


### PR DESCRIPTION
These convenience initializers conflict existing initializers like this because of the default value in the extension.

<img width="807" alt="screen shot 2016-04-25 at 13 39 04" src="https://cloud.githubusercontent.com/assets/2482478/14773976/9253cb66-0aeb-11e6-86e5-245cf850d0fd.png">

I guess the compiler doesn't recognize which one to use. I think it's not good to affect existing APIs.
If you have an idea to this problem, let me know it.

Thanks in advance.
