### PR TITLE
Fix wrong characters.

### DIFF
--- a/Source/TextAttributes.swift
+++ b/Source/TextAttributes.swift
@@ -683,7 +683,7 @@ public class TextAttributes {
     
     // MARK: - Obliqueness
     
-    /// The oliqueness attribute.
+    /// The obliqueness attribute.
     public var obliqueness: CGFloat {
         get {
             return dictionary[NSObliquenessAttributeName] as? CGFloat ?? 0


### PR DESCRIPTION
file: TextAttributed.swift, line: 686, “The oliqueness attribute.” ->
“The obliqueness attribute.”
