### PR TITLE
SWIFT_VERSION for targets other than iOS

### DIFF
--- a/TextAttributes.xcodeproj/project.pbxproj
+++ b/TextAttributes.xcodeproj/project.pbxproj
@@ -736,6 +736,7 @@
 				PRODUCT_NAME = TextAttributes;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 2.2;
 			};
@@ -759,6 +760,7 @@
 				PRODUCT_NAME = TextAttributes;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 2.2;
 			};
@@ -782,6 +784,7 @@
 				PRODUCT_NAME = TextAttributes;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -805,6 +808,7 @@
 				PRODUCT_NAME = TextAttributes;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -858,6 +862,7 @@
 				PRODUCT_NAME = TextAttributes;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -881,6 +886,7 @@
 				PRODUCT_NAME = TextAttributes;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
In the swift 2.3 branch, only iOS target has the _SWIFT_VERSION_ setted.

This PR set the tag for other targets
